### PR TITLE
Update the url and homepage in pkg def with correct URL

### DIFF
--- a/cl-font-lock.el
+++ b/cl-font-lock.el
@@ -5,8 +5,8 @@
 ;; Version: 0.3.0
 ;; Package-Requires: ((emacs "24.5"))
 ;; Keywords: lisp wp files convenience
-;; URL: https://github.com/equwal/coleslaw/
-;; Homepage: https://spensertruex.com/coleslaw
+;; URL: https://github.com/equwal/cl-font-lock
+;; Homepage: https://github.com/equwal/cl-font-lock 
 ;; This file is not part of GNU Emacs, but you want to use  GNU Emacs to run it.
 ;; This file is very free software.
 


### PR DESCRIPTION
If you look at the `describe-package` command from within emacs' package mode, the URL points to the Coleslaw library, and not the correct repository URL.  This PR fixes that by pointing the package definition to this github URL.